### PR TITLE
New: Adicinado ao mapeamento das tabelas com prefixo _matrix as entidades na qual ela faz a ligação

### DIFF
--- a/process.js
+++ b/process.js
@@ -196,13 +196,28 @@ const mapRelations = (entities, relations, files, showWarningMessages = true, sh
 
       mappedEntities[cm] = mappedEntities[cm].map(entity => {
         const targetEntity = mappedEntities[co].find(e => e.directusId === entity[fm]);
-
+    
         if (!targetEntity) {
           if (showWarningMessages) {
             warn(`Could not find an Many-To-One match in ${co} for item in ${cm} ` + `with id ${entity.directusId}. The field value will be left null.`);
           }
 
           return entity;
+        }
+
+        if(cm.includes('_matrix') && cm !== 'ene_matrix') {
+
+          const fieldName = entity.component_collection;
+          const table = mappedEntities[fieldName]
+          let matrixEntity;
+
+          if(table) {
+            matrixEntity =  table.find(e => e.directusId === entity.component_collection_id);
+          }
+
+          if(matrixEntity) {
+            entity[`${fieldName}___NODE`] =   matrixEntity.id 
+          }
         }
 
         const newEntity = { ...entity,


### PR DESCRIPTION
## Description

Foi visto a necessidade de alteração do plugin quando utilizamos relacionamento do tipo matrix, ao qual o plugin não tem suporte. 

A alteração basicamente consiste em retornar a tabela no qual o a entidade _matrix (_padrão foi estabelecido para tabelas desse tipo_) esteja fazendo a ligação. Para poder ter acesso de forma mais facil dos dados no projeto do tic-ecommerce.  

## Motivation and Context

Essa correção impacta diretamente na entrega das task [TED-5317](https://jira.algartelecom.com.br/browse/TED-5317)

